### PR TITLE
replace worker domain with routes & remove origin variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,10 +19,9 @@ module "consufair-lane" {
   cloudflare_api_token = "ExAmPle"
   cloudflare_zone_id = "1337f"
 
-  origin_ip = "1.3.3.7"
   domain = "fairlane.dev"
 
-  create_worker_domain = true
+  create_worker_routes = true
   use_www = true
 }
 
@@ -46,7 +45,7 @@ resource "random_password" "encryption_secret" {
 | `origin_ip`             | `string`  | Required            | -             | IP address of the origin server.                            |
 | `domain`                | `string`  | Required            | -             | Primary domain without the 'www.' prefix.                   |
 | `encryption_secret`     | `string`  | Required            | -             | 256-bit secret key used for encryption.                     |
-| `create_worker_domain`  | `boolean` | Optional            | `false`       | Boolean indicating whether to create a worker domain.       |
+| `create_worker_routes`  | `boolean` | Optional            | `false`       | Boolean indicating whether to create a worker domain.       |
 | `use_www`               | `boolean` | Optional            | `true`        | Boolean indicating whether to include 'www.' in the domain. |
 | `auto_update`           | `boolean` | Optional            | `true`        | Boolean value to enable or disable auto-updates.            |
 | `auto_update_schedule`  | `string`  | Optional            | `*/5 * * * *` | Cron schedule for auto-updates.                             |

--- a/variables.tf
+++ b/variables.tf
@@ -36,16 +36,6 @@ variable "cloudflare_zone_id" {
   description = "Identifier for the Cloudflare zone."
 }
 
-variable "origin_ip" {
-  type        = string
-  description = "IP address of the origin server."
-
-  validation {
-    condition     = can(regex("^\\b(?:\\d{1,3}\\.){3}\\d{1,3}\\b", var.origin_ip))
-    error_message = "Invalid IPv4 address format. Please provide a valid IPv4 address."
-  }
-}
-
 variable "domain" {
   type        = string
   description = "Primary domain without the 'www.' prefix."
@@ -56,10 +46,10 @@ variable "domain" {
   }
 }
 
-variable "create_worker_domain" {
+variable "create_worker_routes" {
   type        = bool
   default     = false
-  description = "Boolean indicating whether to create a worker domain. Defaults to false."
+  description = "Boolean indicating whether to create a worker routes. Defaults to false."
 }
 
 variable "use_www" {

--- a/worker.tf
+++ b/worker.tf
@@ -52,10 +52,10 @@ resource "cloudflare_worker_script" "fairlane_worker" {
 }
 
 resource "cloudflare_worker_cron_trigger" "auto_update" {
+  count       = var.auto_update ? 1 : 0
   account_id  = var.cloudflare_account_id
   script_name = cloudflare_worker_script.fairlane_worker.name
   schedules = [
     var.auto_update_schedule,
   ]
-  count = var.auto_update ? 1 : 0
 }

--- a/worker.tf
+++ b/worker.tf
@@ -16,11 +16,6 @@ resource "cloudflare_worker_script" "fairlane_worker" {
   }
 
   plain_text_binding {
-    name = "ORIGIN_RECORD"
-    text = "${cloudflare_record.origin_record.name}.${var.domain}"
-  }
-
-  plain_text_binding {
     name = "CUSTOMER_ID"
     text = var.fairlane_customer_id
   }

--- a/zone.tf
+++ b/zone.tf
@@ -8,15 +8,15 @@ resource "cloudflare_record" "fairlane_record" {
 }
 
 resource "cloudflare_worker_route" "fairlane" {
+  count       = var.create_worker_routes ? 1 : 0
   zone_id     = var.cloudflare_zone_id
   pattern     = "${var.domain}/*"
   script_name = cloudflare_worker_script.fairlane_worker.name
-  count       = var.create_worker_routes ? 1 : 0
 }
 
 resource "cloudflare_worker_route" "fairlane_record_www" {
+  count       = var.create_worker_routes && var.use_www ? 1 : 0
   zone_id     = var.cloudflare_zone_id
   pattern     = "www.${var.domain}/*"
   script_name = cloudflare_worker_script.fairlane_worker.name
-  count       = var.create_worker_routes && var.use_www ? 1 : 0
 }

--- a/zone.tf
+++ b/zone.tf
@@ -14,7 +14,7 @@ resource "cloudflare_worker_route" "fairlane" {
   count       = var.create_worker_routes ? 1 : 0
 }
 
-resource "cloudflare_worker_route" "fairlane_www" {
+resource "cloudflare_worker_route" "fairlane_record_www" {
   zone_id     = var.cloudflare_zone_id
   pattern     = "www.${var.domain}/*"
   script_name = cloudflare_worker_script.fairlane_worker.name

--- a/zone.tf
+++ b/zone.tf
@@ -1,12 +1,3 @@
-resource "cloudflare_record" "origin_record" {
-  zone_id = var.cloudflare_zone_id
-  name    = "origin"
-  value   = var.origin_ip
-  type    = "A"
-  ttl     = 1
-  proxied = true
-}
-
 resource "cloudflare_record" "fairlane_record" {
   zone_id = var.cloudflare_zone_id
   name    = "fairlane"
@@ -20,27 +11,12 @@ resource "cloudflare_worker_route" "fairlane" {
   zone_id     = var.cloudflare_zone_id
   pattern     = "${var.domain}/*"
   script_name = cloudflare_worker_script.fairlane_worker.name
+  count       = var.create_worker_routes ? 1 : 0
 }
 
 resource "cloudflare_worker_route" "fairlane_www" {
   zone_id     = var.cloudflare_zone_id
   pattern     = "www.${var.domain}/*"
   script_name = cloudflare_worker_script.fairlane_worker.name
-  count       = var.use_www ? 1 : 0
-}
-
-resource "cloudflare_worker_domain" "fairlane" {
-  account_id = var.cloudflare_account_id
-  zone_id    = var.cloudflare_zone_id
-  service    = cloudflare_worker_script.fairlane_worker.name
-  hostname   = var.domain
-  count      = var.create_worker_domain ? 1 : 0
-}
-
-resource "cloudflare_worker_domain" "fairlane_www" {
-  account_id = var.cloudflare_account_id
-  zone_id    = var.cloudflare_zone_id
-  service    = cloudflare_worker_script.fairlane_worker.name
-  hostname   = "www.${var.domain}"
-  count      = var.create_worker_domain && var.use_www ? 1 : 0
+  count       = var.create_worker_routes && var.use_www ? 1 : 0
 }


### PR DESCRIPTION
This PR removes the dependency of using a separate origin record.
Instead we use Cloudflare's existing records by using Worker routes.
Preventing downtime because there is no need to replace existing records with a worker domain.